### PR TITLE
Check for the same workchain

### DIFF
--- a/contracts/jetton-wallet.fc
+++ b/contracts/jetton-wallet.fc
@@ -146,6 +146,8 @@
 }
 
 () burn_jettons(slice in_msg_body, slice sender_address, int msg_value) impure inline_ref {
+    slice to_owner_address = in_msg_body~load_msg_addr();
+    check_same_workchain(to_owner_address);
     (int status, int balance, slice owner_address, slice jetton_master_address) = load_data();
     int query_id = in_msg_body~load_query_id();
     int jetton_amount = in_msg_body~load_coins();


### PR DESCRIPTION
I'm not 100% sure how the logic of the current smart contract should work.
But when executing the burn_jettons function, we can check the channel.
Without this, loss of tokens is possible, but it all depends on the architecture.