### PR TITLE
Perhaps this 0 also contains a specification

### DIFF
--- a/contracts/jetton.tlb
+++ b/contracts/jetton.tlb
@@ -37,7 +37,7 @@ _ grams:Grams = Coins;
 // TEP - 74
 // https://github.com/ton-blockchain/TEPs/blob/master/text/0074-jettons-standard.md
 
-transfer#0f8a7ea5
+transfer#f8a7ea5
   query_id:uint64
   amount:Coins
   destination:MsgAddress


### PR DESCRIPTION
f8a7ea5 => 0xf8a7ea5

This 0 should definitely be in the TEP-74?
eg: take_wallet_address#d1735400