### PR TITLE
FIX recv_internal m_1

### DIFF
--- a/contracts/jetton-wallet.fc
+++ b/contracts/jetton-wallet.fc
@@ -193,6 +193,10 @@
 }
 
 () recv_internal(int my_ton_balance, int msg_value, cell in_msg_full, slice in_msg_body) impure {
+    if (in_msg_body.slice_empty?()) { ;; ignore empty messages
+      return ();
+    }
+
     slice in_msg_full_slice = in_msg_full.begin_parse();
     int msg_flags = in_msg_full_slice~load_msg_flags();
     if (is_bounced(msg_flags)) {


### PR DESCRIPTION
if is_bounced skips empty body
https://github.com/ton-blockchain/token-contract/blob/369ae089255edbd807eb499792a0a838c2e1b272/ft/jetton-wallet.fc#L202
Perhaps it is better to wrap this `check` in a function and start using it in other places.